### PR TITLE
レシピのカロリーと塩分を表示できるようにした

### DIFF
--- a/app/Domain/Models/AjikkoRecipeEiyo.php
+++ b/app/Domain/Models/AjikkoRecipeEiyo.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Domain\Models;
+
+class AjikkoRecipeEiyo
+{
+    public function __construct
+    (
+        public string $name,
+        public string $volume,
+        public string $enercKcal,
+        public string $naclEq,
+    ) {}
+
+    public function calorie()
+    {
+        return $this->enercKcal * ($this->volume / 100);
+    }
+
+    public function salt()
+    {
+        return $this->naclEq * ($this->volume / 100);
+    }
+
+}

--- a/app/Domain/Models/AjikkoRecipeWithEiyo.php
+++ b/app/Domain/Models/AjikkoRecipeWithEiyo.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Domain\Models;
+
+use Illuminate\Support\Collection;
+
+class AjikkoRecipeWithEiyo
+{
+    public function __construct
+    (
+        public int $id,
+        public string $title,
+        public string $description,
+        public string $sourceUrl,
+        public string $foodImageUrl,
+        public string $mediumImageUrl,
+        public string $smallImageUrl,
+        public string $createdAt,
+        public string $updatedAt,
+        public Collection $eiyos,
+    ) {}
+
+    public function calorie():string
+    {
+        return (string)$this->eiyos->sum(function(AjikkoRecipeEiyo $eiyo){
+            return $eiyo->calorie();
+        });
+    }
+
+    public function salt():string
+    {
+        return (string)$this->eiyos->sum(function(AjikkoRecipeEiyo $eiyo){
+            return $eiyo->salt();
+        });
+    }
+
+}

--- a/app/Http/Controllers/RecipeController.php
+++ b/app/Http/Controllers/RecipeController.php
@@ -3,26 +3,35 @@
 namespace App\Http\Controllers;
 
 
-use App\Models\RakutenRecipe;
+use App\Models\AjikkoRecipe;
 
 class RecipeController extends Controller
 {
     public function index()
     {
+        $recipes = AjikkoRecipe::all()->map(function(AjikkoRecipe $ajikkoRecipe){
+            return $ajikkoRecipe->toDomain();
+        });
         $params = [
-            'recipes' =>RakutenRecipe::query()->paginate(30)
+            'recipes' => $recipes,
         ];
         return view('recipes/index', $params);
     }
 
     public function show($id)
     {
+        $ajikkoRecipe = AjikkoRecipe::findOrFail($id)->toDomain();
+        $relatedRecipes = AjikkoRecipe::query()
+            ->where('id', '!=', $id)
+            ->inRandomOrder()
+            ->limit(8)
+            ->get()
+            ->map(function(AjikkoRecipe $ajikkoRecipe){
+                return $ajikkoRecipe->toDomain();
+            });
         $params = [
-            'recipe' => RakutenRecipe::findOrFail($id),
-            'relatedRecipes' => RakutenRecipe::query()
-                ->inRandomOrder()
-                ->limit(8)
-                ->get(),
+            'recipe' => $ajikkoRecipe,
+            'relatedRecipes' => $relatedRecipes,
         ];
         return view('recipes/show', $params);
     }

--- a/app/Models/AjikkoRecipe.php
+++ b/app/Models/AjikkoRecipe.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use App\Domain\Models\AjikkoRecipeWithEiyo;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class AjikkoRecipe extends Model
+{
+    use SoftDeletes;
+
+    protected $guarded = [
+        'created_at',
+        'updated_at',
+    ];
+
+    public function eiyos()
+    {
+        return $this->hasMany(AjikkoRecipeEiyo::class);
+    }
+
+    public function toDomain():AjikkoRecipeWithEiyo
+    {
+        $eiyoCollection = $this->eiyos->map(function($eiyo){
+            return new \App\Domain\Models\AjikkoRecipeEiyo(
+                $eiyo->eiyo->food_name,
+                $eiyo->volume,
+                $eiyo->eiyo->enerc_kcal,
+                $eiyo->eiyo->nacl_eq,
+            );
+        });
+        return new AjikkoRecipeWithEiyo(
+            $this->id,
+            $this->title,
+            $this->description,
+            $this->source_url,
+            $this->food_image_url,
+            $this->medium_image_url,
+            $this->small_image_url,
+            $this->created_at,
+            $this->updated_at,
+            $eiyoCollection
+        );
+    }
+}

--- a/app/Models/AjikkoRecipeEiyo.php
+++ b/app/Models/AjikkoRecipeEiyo.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AjikkoRecipeEiyo extends Model
+{
+    public function eiyo()
+    {
+        return $this->hasOne(Eiyo::class, 'id', 'eiyo_id');
+    }
+}

--- a/app/Models/Eiyo.php
+++ b/app/Models/Eiyo.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Eiyo extends Model
+{
+    use HasFactory;
+}

--- a/database/migrations/2022_12_31_090926_create_ajikko_recipes_table.php
+++ b/database/migrations/2022_12_31_090926_create_ajikko_recipes_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('ajikko_recipes', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('description');
+            $table->string('source_url');
+            $table->string('food_image_url');
+            $table->string('medium_image_url');
+            $table->string('small_image_url');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('ajikko_recipes');
+    }
+};

--- a/database/migrations/2022_12_31_090953_create_ajikko_recipe_eiyos_table.php
+++ b/database/migrations/2022_12_31_090953_create_ajikko_recipe_eiyos_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('ajikko_recipe_eiyos', function (Blueprint $table) {
+            $table->unsignedBigInteger('ajikko_recipe_id');
+            $table->unsignedBigInteger('eiyo_id');
+            $table->unsignedSmallInteger('volume');
+
+            $table->foreign('ajikko_recipe_id')
+                ->references('id')
+                ->on('ajikko_recipes');
+            $table->foreign('eiyo_id')
+                ->references('id')
+                ->on('eiyos');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('ajikko_recipe_eiyos');
+    }
+};

--- a/database/seeders/AjikkoRecipeSeeder.php
+++ b/database/seeders/AjikkoRecipeSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\AjikkoRecipe;
+use App\Models\RakutenRecipe;
+use Illuminate\Database\Seeder;
+
+class AjikkoRecipeSeeder extends Seeder
+{
+    private const ADOPTED_RECIPE_IDS = [
+        1570003792,
+        1860023243,
+    ];
+
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        RakutenRecipe::query()
+            ->whereIn('id', self::ADOPTED_RECIPE_IDS)
+            ->get()
+            ->each(function(RakutenRecipe $rakutenRecipe){
+                AjikkoRecipe::updateOrCreate([
+                    'source_url' => $rakutenRecipe->url
+                ],[
+                    'title' => $rakutenRecipe->title,
+                    'description' => $rakutenRecipe->description,
+                    'food_image_url' => $rakutenRecipe->food_image_url,
+                    'medium_image_url' => $rakutenRecipe->medium_image_url,
+                    'small_image_url' => $rakutenRecipe->small_image_url,
+                ]);
+            });
+    }
+}

--- a/resources/views/recipes/index.blade.php
+++ b/resources/views/recipes/index.blade.php
@@ -134,26 +134,26 @@
                 @foreach($recipes as $recipe)
                     <div class="group relative flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white">
                         <div class="aspect-w-3 aspect-h-4 bg-gray-200 group-hover:opacity-75 sm:aspect-none sm:h-46">
-                            <img src="{{ $recipe->food_image_url }}">
+                            <img src="{{ $recipe->foodImageUrl }}">
                         </div>
                         <div class="flex flex-1 flex-col space-y-2 p-4">
                             <h3 class="text-sm font-medium text-gray-900">
                                 <a href="{{ route('recipes-show', ['id' => $recipe->id]) }}">
                                     <span aria-hidden="true" class="absolute inset-0"></span>
-                                    {{ $recipe->name }}
+                                    {{ $recipe->title }}
                                 </a>
                             </h3>
                             <p class="text-sm text-gray-500">{{ $recipe->description }}</p>
                             <div class="flex flex-1 flex-col justify-end">
-                                <p class="text-sm italic text-gray-500">8 colors</p>
-                                <p class="text-base font-medium text-gray-900">$256</p>
+{{--                                <p class="text-sm italic text-gray-500">8 colors</p>--}}
+                                <p class="text-base font-medium text-gray-900">{{ $recipe->calorie() }}kcal</p>
                             </div>
                         </div>
                     </div>
                 @endforeach
             </div>
 
-            {{ $recipes->links('vendor/pagination/tailwind') }}
+{{--            {{ $recipes->links('vendor/pagination/tailwind') }}--}}
 
         </section>
     </div>

--- a/resources/views/recipes/show.blade.php
+++ b/resources/views/recipes/show.blade.php
@@ -8,7 +8,7 @@
         <!-- Product image -->
         <div class="lg:col-span-4 lg:row-end-1">
             <div class="aspect-w-4 aspect-h-3 overflow-hidden rounded-lg bg-gray-100">
-                <img src="{{ $recipe->food_image_url }}" alt="{{ $recipe->title }}" class="object-cover object-center">
+                <img src="{{ $recipe->foodImageUrl }}" alt="{{ $recipe->title }}" class="object-cover object-center">
             </div>
         </div>
 
@@ -19,7 +19,7 @@
                     <h1 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">{{ $recipe->title }}</h1>
 
                     <h2 id="information-heading" class="sr-only">Product information</h2>
-                    <p class="mt-2 text-sm text-gray-500">公開日：<time datetime="{{ $recipe->publishday }}">{{ $recipe->publishday }}</time></p>
+                    <p class="mt-2 text-sm text-gray-500">更新日：<time datetime="{{ $recipe->updatedAt }}">{{ $recipe->updatedAt }}</time></p>
                 </div>
 
                 <div>
@@ -58,10 +58,27 @@
                 </div>
             </div>
 
+            <dl class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-3">
+                <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+                    <dt class="truncate text-sm font-medium text-gray-500">Calorie</dt>
+                    <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">{{ $recipe->calorie() }}</dd>
+                </div>
+
+                <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+                    <dt class="truncate text-sm font-medium text-gray-500">Salt</dt>
+                    <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">{{ $recipe->salt() }}</dd>
+                </div>
+
+                <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+                    <dt class="truncate text-sm font-medium text-gray-500">-</dt>
+                    <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">-</dd>
+                </div>
+            </dl>
+
             <p class="mt-6 text-gray-500">{{ $recipe->description }}</p>
 
             <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
-                <a target="_blank" href="{{ $recipe->url }}"><button type="button" class="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 py-3 px-8 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50">楽天レシピ</button></a>
+                <a target="_blank" href="{{ $recipe->sourceUrl }}"><button type="button" class="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 py-3 px-8 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50">楽天レシピ</button></a>
                 <button type="button" class="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-50 py-3 px-8 text-base font-medium text-indigo-700 hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50">Preview</button>
             </div>
 
@@ -69,8 +86,8 @@
                 <h3 class="text-sm font-medium text-gray-900">材料</h3>
                 <div class="prose prose-sm mt-4 text-gray-500">
                     <ul role="list">
-                        @foreach($recipe->material as $material)
-                            <li>{{ $material }}</li>
+                        @foreach($recipe->eiyos as $eiyo)
+                            <li>{{ $eiyo->name }} {{ $eiyo->calorie() }}kcal</li>
                         @endforeach
                     </ul>
                 </div>
@@ -237,7 +254,7 @@
             @foreach($relatedRecipes as $recipe)
             <div class="group relative">
                 <div class="aspect-w-4 aspect-h-3 overflow-hidden rounded-lg bg-gray-100">
-                    <img src="{{ $recipe->food_image_url }}" alt="{{ $recipe->title }}" class="object-cover object-center">
+                    <img src="{{ $recipe->foodImageUrl }}" alt="{{ $recipe->title }}" class="object-cover object-center">
                     <div class="flex items-end p-4 opacity-0 group-hover:opacity-100" aria-hidden="true">
                         <div class="w-full rounded-md bg-white bg-opacity-75 py-2 px-4 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter">View Recipe</div>
                     </div>
@@ -249,7 +266,7 @@
                             {{ $recipe->title }}
                         </a>
                     </h3>
-{{--                    <p>$49</p>--}}
+                    <p>{{ $recipe->calorie() }}kcal</p>
                 </div>
 {{--                <p class="mt-1 text-sm text-gray-500">UI Kit</p>--}}
             </div>


### PR DESCRIPTION
- [x] サービス表示用のレシピ情報格納テーブル作成
- [x] 表示用レシピの栄養素とグラムを保存する中間テーブル作成
- [x] レシピと食品の紐付けとグラムが入力されていればカロリーと塩分を計算して表示する
- [x] 材料別のカロリーを表示する 


| トップ  | レシピ詳細ページ1 | レシピ詳細ページ2 | 紐付けデータの感じ |
| ------------- | ------------- | ------------- | ------------- |
| ![スクリーンショット 2022-12-31 11 29 53](https://user-images.githubusercontent.com/4530978/210122404-3d388b3b-f29c-4340-99c6-dd6c9cb861da.png)  | ![スクリーンショット 2022-12-31 11 30 28](https://user-images.githubusercontent.com/4530978/210122414-8022645f-c578-4f46-a668-c84b74b1993b.png) | ![スクリーンショット 2022-12-31 11 37 24](https://user-images.githubusercontent.com/4530978/210122578-25ea7ef7-8c69-405b-89b2-c563267fc1fd.png) | ![スクリーンショット 2022-12-31 11 36 07](https://user-images.githubusercontent.com/4530978/210122548-c0c57112-4f33-45e8-b8a6-c091a49176c1.png) |


